### PR TITLE
Remove Cloud Foundry

### DIFF
--- a/_includes/docs/0.4.x/index.html
+++ b/_includes/docs/0.4.x/index.html
@@ -38,8 +38,6 @@
 
     {% include docs/0.4.x/gettingstarted.html %}
 
-    {% include docs/0.4.x/cloud-foundry.html %}
-
     {% include docs/0.4.x/troubleshooting.html %}
     
     {% include docs/0.4.x/servertests.html %}


### PR DESCRIPTION
The command ```jekyll serve``` will fail.
Could not locate the included file 'docs/0.4.x/cloud-foundry.html
Remove include as commit https://github.com/meanjs/meanjs.github.io/commit/dd26fb892e332ceef6e84461ea4eaa86b0e5a554